### PR TITLE
Refactor settings page to improve modularity and performance

### DIFF
--- a/src/components/settings/DocumentTypesTab.tsx
+++ b/src/components/settings/DocumentTypesTab.tsx
@@ -1,36 +1,90 @@
-
-import React from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
 import { Plus, Edit, Trash2 } from "lucide-react";
 import { DocumentType } from "@/lib/types";
 import { ItemFormDialog } from "./ItemFormDialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { getDocumentTypes, addDocumentType, updateDocumentType, deleteDocumentType } from "@/lib/document-types";
+import { useToast } from "@/hooks/use-toast";
+import { Skeleton } from "@/components/ui/skeleton";
 
-interface DocumentTypesTabProps {
-  documentTypes: DocumentType[];
-  onAddDocumentType: (name: string) => void;
-  onUpdateDocumentType: (id: string, name: string) => void;
-  onDeleteDocumentType: (id: string) => void;
-}
+export const DocumentTypesTab: React.FC = () => {
+  const [documentTypes, setDocumentTypes] = useState<DocumentType[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [editingItem, setEditingItem] = useState<{ id: string; name: string } | null>(null);
+  const [itemToDelete, setItemToDelete] = useState<DocumentType | null>(null);
+  const { toast } = useToast();
 
-export const DocumentTypesTab: React.FC<DocumentTypesTabProps> = ({
-  documentTypes,
-  onAddDocumentType,
-  onUpdateDocumentType,
-  onDeleteDocumentType,
-}) => {
-  const [isDialogOpen, setIsDialogOpen] = React.useState(false);
-  const [editingItem, setEditingItem] = React.useState<{ id: string; name: string } | null>(null);
-
-  const handleSubmit = (data: { itemName: string }) => {
-    if (editingItem) {
-      onUpdateDocumentType(editingItem.id, data.itemName);
-    } else {
-      onAddDocumentType(data.itemName);
+  const loadDocumentTypes = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      const docTypesData = await getDocumentTypes();
+      setDocumentTypes(docTypesData);
+    } catch (error) {
+      console.error("Error loading document types:", error);
+      toast({
+        title: "Error",
+        description: "Failed to load document types.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsLoading(false);
     }
-    setIsDialogOpen(false);
-    setEditingItem(null);
+  }, [toast]);
+
+  useEffect(() => {
+    loadDocumentTypes();
+  }, [loadDocumentTypes]);
+
+  const handleSubmit = async (data: { itemName: string }) => {
+    try {
+      if (editingItem) {
+        await updateDocumentType({ id: editingItem.id, name: data.itemName });
+        toast({ title: "Document type updated", description: `${data.itemName} has been updated.` });
+      } else {
+        await addDocumentType(data.itemName);
+        toast({ title: "Document type added", description: `${data.itemName} has been added.` });
+      }
+      setIsDialogOpen(false);
+      setEditingItem(null);
+      loadDocumentTypes();
+    } catch (error) {
+      console.error("Error saving document type:", error);
+      toast({ title: "Error", description: "Failed to save document type.", variant: "destructive" });
+    }
+  };
+
+  const handleDeleteClick = (item: DocumentType) => {
+    setItemToDelete(item);
+    setIsDeleteDialogOpen(true);
+  };
+
+  const confirmDelete = async () => {
+    if (itemToDelete) {
+      try {
+        await deleteDocumentType(itemToDelete.id);
+        toast({ title: "Document type deleted", description: `The document type has been deleted.` });
+        setIsDeleteDialogOpen(false);
+        setItemToDelete(null);
+        loadDocumentTypes();
+      } catch (error) {
+        console.error("Error deleting document type:", error);
+        toast({ title: "Error", description: "Failed to delete document type.", variant: "destructive" });
+      }
+    }
   };
 
   const columns = [
@@ -61,7 +115,7 @@ export const DocumentTypesTab: React.FC<DocumentTypesTabProps> = ({
             size="icon"
             onClick={(e) => {
               e.stopPropagation();
-              onDeleteDocumentType(row.id);
+              handleDeleteClick(row);
             }}
           >
             <Trash2 className="w-4 h-4 text-destructive" />
@@ -92,7 +146,15 @@ export const DocumentTypesTab: React.FC<DocumentTypesTabProps> = ({
         </div>
       </CardHeader>
       <CardContent>
-        <DataTable data={documentTypes} columns={columns} />
+        {isLoading ? (
+          <div className="space-y-4">
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+          </div>
+        ) : (
+          <DataTable data={documentTypes} columns={columns} />
+        )}
       </CardContent>
       
       <ItemFormDialog 
@@ -101,10 +163,28 @@ export const DocumentTypesTab: React.FC<DocumentTypesTabProps> = ({
         onSubmit={handleSubmit}
         title={editingItem ? "Edit Document Type" : "Add New Document Type"}
         description={editingItem ? "Update the document type." : "Enter a name for the new document type."}
-        placeholder="e.g., Exam"
+        placeholder="e.g., Exam, Homework, etc."
+        label="Document Type Name"
         isEditing={!!editingItem}
         initialValue={editingItem?.name || ""}
       />
+
+      <AlertDialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Are you sure?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This action will delete the document type "{itemToDelete?.name}". This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={confirmDelete} className="bg-destructive text-destructive-foreground">
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </Card>
   );
 };

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -1,226 +1,39 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { GeneralSettingsTab } from "@/components/settings/GeneralSettingsTab";
 import { ClassesTab } from "@/components/settings/ClassesTab";
 import { TeachersTab } from "@/components/settings/TeachersTab";
 import { DocumentTypesTab } from "@/components/settings/DocumentTypesTab";
-import { getSettings, updateSettings } from "@/lib/settings";
-import { getClasses, addClass, updateClass, deleteClass } from "@/lib/classes";
-import { getTeachers, addTeacher, updateTeacher, deleteTeacher } from "@/lib/teachers";
-import { getDocumentTypes, addDocumentType, updateDocumentType, deleteDocumentType } from "@/lib/document-types";
-import { useToast } from "@/hooks/use-toast";
-import type { Settings as SettingsType } from "@/lib/types";
 import { SettingsHeader } from "./SettingsHeader";
+import { BackupRestoreSection } from "./BackupRestoreSection";
 
 const Settings = () => {
-  const [settings, setSettings] = useState<SettingsType>({
-    shopName: "",
-    contactInfo: "",
-    priceRecto: 0.10,
-    priceRectoVerso: 0.15,
-    priceBoth: 0.25,
-    maxUnpaidThreshold: 100,
-    whatsappTemplate: "",
-    defaultSavePath: "",
-    enableAutoPdfSave: true,
-    enableWhatsappNotification: true,
-    enableAutoPaidNotification: false
-  });
-  const [activeTab, setActiveTab] = useState("general");
-  const { toast } = useToast();
-  
-  const [classes, setClasses] = useState([]);
-  const [teachers, setTeachers] = useState([]);
-  const [documentTypes, setDocumentTypes] = useState([]);
-  
-  useEffect(() => {
-    const loadData = async () => {
-      try {
-        // Load settings on component mount
-        const loadedSettings = await getSettings();
-        setSettings(loadedSettings);
-        
-        // Load data for other tabs
-        const classesData = await getClasses();
-        setClasses(classesData);
-        
-        const teachersData = await getTeachers();
-        setTeachers(teachersData);
-        
-        const docTypesData = await getDocumentTypes();
-        setDocumentTypes(docTypesData);
-      } catch (error) {
-        console.error("Error loading data:", error);
-        toast({
-          title: "Error loading settings",
-          description: "Failed to load settings data.",
-          variant: "destructive",
-        });
-      }
-    };
-    
-    loadData();
-  }, [toast]);
-
-  const handleUpdateSettings = async (updatedSettings: SettingsType) => {
-    try {
-      await updateSettings(updatedSettings);
-      setSettings(updatedSettings);
-      
-      toast({
-        title: "Settings updated",
-        description: "Your settings have been saved successfully.",
-        variant: "default",
-      });
-    } catch (error) {
-      console.error("Error saving settings:", error);
-      toast({
-        title: "Error saving settings",
-        description: "Failed to save your settings.",
-        variant: "destructive",
-      });
-    }
-  };
-
-  // Class handlers
-  const handleAddClass = async (name: string) => {
-    const newClass = await addClass(name);
-    const updatedClasses = await getClasses();
-    setClasses(updatedClasses);
-    
-    toast({
-      title: "Class added",
-      description: `${name} has been added successfully.`,
-      variant: "default",
-    });
-  };
-
-  const handleUpdateClass = async (id: string, name: string) => {
-    await updateClass(id, name);
-    const updatedClasses = await getClasses();
-    setClasses(updatedClasses);
-    
-    toast({
-      title: "Class updated",
-      description: `${name} has been updated successfully.`,
-      variant: "default",
-    });
-  };
-
-  const handleDeleteClass = async (id: string) => {
-    await deleteClass(id);
-    const updatedClasses = await getClasses();
-    setClasses(updatedClasses);
-    
-    toast({
-      title: "Class deleted",
-      description: "The class has been deleted successfully.",
-      variant: "default",
-    });
-  };
-
-  // Teacher handlers
-  const handleAddTeacher = (name: string) => {
-    const newTeacher = addTeacher(name);
-    setTeachers(getTeachers());
-    toast({
-      title: "Teacher added",
-      description: `${name} has been added successfully.`,
-      variant: "default",
-    });
-  };
-
-  const handleUpdateTeacher = (id: string, name: string) => {
-    updateTeacher({ id, name });
-    setTeachers(getTeachers());
-    toast({
-      title: "Teacher updated",
-      description: `${name} has been updated successfully.`,
-      variant: "default",
-    });
-  };
-
-  const handleDeleteTeacher = (id: string) => {
-    deleteTeacher(id);
-    setTeachers(getTeachers());
-    toast({
-      title: "Teacher deleted",
-      description: "The teacher has been deleted successfully.",
-      variant: "default",
-    });
-  };
-
-  // Document type handlers
-  const handleAddDocumentType = (name: string) => {
-    const newDocType = addDocumentType(name);
-    setDocumentTypes(getDocumentTypes());
-    toast({
-      title: "Document type added",
-      description: `${name} has been added successfully.`,
-      variant: "default",
-    });
-  };
-
-  const handleUpdateDocumentType = (id: string, name: string) => {
-    updateDocumentType({ id, name });
-    setDocumentTypes(getDocumentTypes());
-    toast({
-      title: "Document type updated",
-      description: `${name} has been updated successfully.`,
-      variant: "default",
-    });
-  };
-
-  const handleDeleteDocumentType = (id: string) => {
-    deleteDocumentType(id);
-    setDocumentTypes(getDocumentTypes());
-    toast({
-      title: "Document type deleted",
-      description: "The document type has been deleted successfully.",
-      variant: "default",
-    });
-  };
-
   return (
     <div className="space-y-6">
       <SettingsHeader />
 
-      <Tabs value={activeTab} onValueChange={setActiveTab}>
+      <Tabs defaultValue="general">
         <TabsList className="w-full border-b rounded-none justify-start">
           <TabsTrigger value="general">General</TabsTrigger>
           <TabsTrigger value="classes">Classes</TabsTrigger>
           <TabsTrigger value="teachers">Teachers</TabsTrigger>
           <TabsTrigger value="documents">Document Types</TabsTrigger>
+          <TabsTrigger value="backup">Backup & Restore</TabsTrigger>
         </TabsList>
         <TabsContent value="general" className="py-4">
-          <GeneralSettingsTab 
-            settings={settings} 
-            onUpdateSettings={handleUpdateSettings} 
-          />
+          <GeneralSettingsTab />
         </TabsContent>
         <TabsContent value="classes" className="py-4">
-          <ClassesTab 
-            classes={classes} 
-            onAddClass={handleAddClass}
-            onUpdateClass={handleUpdateClass}
-            onDeleteClass={handleDeleteClass}
-          />
+          <ClassesTab />
         </TabsContent>
         <TabsContent value="teachers" className="py-4">
-          <TeachersTab 
-            teachers={teachers}
-            onAddTeacher={handleAddTeacher}
-            onUpdateTeacher={handleUpdateTeacher}
-            onDeleteTeacher={handleDeleteTeacher}
-          />
+          <TeachersTab />
         </TabsContent>
         <TabsContent value="documents" className="py-4">
-          <DocumentTypesTab 
-            documentTypes={documentTypes}
-            onAddDocumentType={handleAddDocumentType}
-            onUpdateDocumentType={handleUpdateDocumentType}
-            onDeleteDocumentType={handleDeleteDocumentType}
-          />
+          <DocumentTypesTab />
+        </TabsContent>
+        <TabsContent value="backup" className="py-4">
+          <BackupRestoreSection />
         </TabsContent>
       </Tabs>
     </div>


### PR DESCRIPTION
The main Settings component was acting as a single, monolithic unit, responsible for fetching data and managing state for all its child tabs (General, Classes, Teachers, Document Types). This resulted in a "fat component" that was inefficient and difficult to maintain, as it loaded all data for all tabs at once, regardless of which tab was active.

This commit refactors the settings page by moving the data fetching, state management, and CRUD logic into their respective tab components. Each tab is now a self-contained unit responsible for its own data and behavior.

Key changes:
- **`GeneralSettingsTab`, `ClassesTab`, `TeachersTab`, `DocumentTypesTab`**: These components are now self-contained. They fetch their own data on mount, manage their own state (including loading and dialog states), and handle their own CRUD operations.
- **`src/pages/settings/index.tsx`**: This component has been significantly simplified. It is now a pure layout component that renders the `Tabs` container and the individual tab components, without passing any props.
- **Performance**: Data for each tab is now loaded lazily when the tab is activated, improving the initial load time of the settings page.
- **UI/UX**: Added skeleton loaders to each tab to provide better visual feedback to the user while data is being fetched.
- **Consistency**: Added a confirmation dialog for deleting teachers and document types to match the behavior of the classes tab.
- **New Feature**: Integrated the existing `BackupRestoreSection` as a new "Backup & Restore" tab, making the settings page more comprehensive.